### PR TITLE
Make the response match the exact hex equivalent of SHOUTcast.

### DIFF
--- a/intern/inputParser/shoutcast.js
+++ b/intern/inputParser/shoutcast.js
@@ -24,7 +24,7 @@ var listener = tcp.createServer(function(c) {
                 c.end()
                 return
             }
-            c.write("OK2\r\nicy-caps:11\n\n");
+            c.write("OK2\r\nicy-caps:11\r\n\r\n");
             
             if (input.length > 1) {
                 icy = parseICY(input)


### PR DESCRIPTION
Out of hex dumps of the network traffic of SHOUTcast this should be the correct way to send OK2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/cast/15)
<!-- Reviewable:end -->
