### PR TITLE
Add a delay up to 10 seconds is antiStreamripper is in config

### DIFF
--- a/intern/streams/streams.js
+++ b/intern/streams/streams.js
@@ -176,7 +176,7 @@ const getStreamMetadata = (streamName) => {
     return streamMetadata[streamName] || {}
 }
 const setStreamMetadata = (streamName, data) => {
-    if (config.antiStreamripper) {
+    if (config.antiStreamRipper) {
         setTimeout(setStreamMetadataNow, 1000 * (Math.random() * 10), streamName, data)
     } else {
         setStreamMetadataNow(streamName, data)

--- a/intern/streams/streams.js
+++ b/intern/streams/streams.js
@@ -175,8 +175,18 @@ const isStreamInUse = (streamName) => {
 const getStreamMetadata = (streamName) => {
     return streamMetadata[streamName] || {}
 }
-
 const setStreamMetadata = (streamName, data) => {
+    if (config.antiStreamripper) {
+        setTimeout(setStreamMetadataNow, 1000 * (Math.random() * 10), streamName, data)
+    } else {
+        setStreamMetadataNow(streamName, data)
+    }
+}
+
+const setStreamMetadataNow = (streamName, data) => {
+    if (!isStreamInUse(streamName)) {
+        return // prevents race conditions with anti-streamripper
+    }
     data.time = Math.round((new Date()).getTime() / 1000)
     streamMetadata[streamName] = data
     if (typeof streamPastMetadata[streamName] === "undefined") {


### PR DESCRIPTION
Added a boolean with the name `antiStreamripper ` in the config file. If this is enabled it will random delay metadata updates. This way streamrippers can't cut songs using metadata updates

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/cast/24)
<!-- Reviewable:end -->
