### PR TITLE
Add the hideListenerCount option

### DIFF
--- a/intern/HTTP/apps/front.js
+++ b/intern/HTTP/apps/front.js
@@ -20,7 +20,7 @@ export default (app) => {
                 meta,
                 streams: activeStreams,
                 currentStream: stream,
-                listencount: config.hideListenerCount ? false : streams.numberOfListerners(stream),
+                listencount: config.hideListenerCount ? null : streams.numberOfListerners(stream),
                 hostname: config.hostname,
                 geolockIsAllowed,
             }))
@@ -49,7 +49,7 @@ export default (app) => {
                 meta,
                 streams: streams.getActiveStreams(),
                 currentStream: req.params[0],
-                listencount: config.hideListenerCount ? false : streams.numberOfListerners(req.params[0]),
+                listencount: config.hideListenerCount ? null : streams.numberOfListerners(req.params[0]),
                 hostname: config.hostname,
                 geolockIsAllowed,
             }))

--- a/intern/HTTP/apps/front.js
+++ b/intern/HTTP/apps/front.js
@@ -20,7 +20,7 @@ export default (app) => {
                 meta,
                 streams: activeStreams,
                 currentStream: stream,
-                listencount: streams.numberOfListerners(stream),
+                listencount: config.hideListenerCount ? false : streams.numberOfListerners(stream),
                 hostname: config.hostname,
                 geolockIsAllowed,
             }))
@@ -49,7 +49,7 @@ export default (app) => {
                 meta,
                 streams: streams.getActiveStreams(),
                 currentStream: req.params[0],
-                listencount: streams.numberOfListerners(req.params[0]),
+                listencount: config.hideListenerCount ? false : streams.numberOfListerners(req.params[0]),
                 hostname: config.hostname,
                 geolockIsAllowed,
             }))

--- a/intern/HTTP/apps/shoutcastv2.js
+++ b/intern/HTTP/apps/shoutcastv2.js
@@ -175,10 +175,10 @@ const streamAdminStats = (req, res) => {
     let output
     if (streams.isStreamInUse(stream)) {
         output = {
-            "currentlisteners": streams.numberOfListerners(stream),
-            "peaklisteners": streams.numberOfListerners(stream),
+            "currentlisteners": streams.numberOfListerners(stream, true),
+            "peaklisteners": streams.numberOfListerners(stream, true),
             "maxlisteners": 9999,
-            "uniquelisteners": streams.numberOfUniqueListerners(stream),
+            "uniquelisteners": streams.numberOfUniqueListerners(stream, true),
             "averagetime": 0,
             "servergenre": streams.getStreamConf(stream).genre,
             "servergenre2": "",

--- a/intern/HTTP/apps/shoutcastv2.js
+++ b/intern/HTTP/apps/shoutcastv2.js
@@ -175,10 +175,10 @@ const streamAdminStats = (req, res) => {
     let output
     if (streams.isStreamInUse(stream)) {
         output = {
-            "currentlisteners": streams.numberOfListerners(stream, true),
-            "peaklisteners": streams.numberOfListerners(stream, true),
+            "currentlisteners": streams.realNumberOfListerners(stream),
+            "peaklisteners": streams.realNumberOfListerners(stream),
             "maxlisteners": 9999,
-            "uniquelisteners": streams.numberOfUniqueListerners(stream, true),
+            "uniquelisteners": streams.realNumberOfUniqueListerners(stream),
             "averagetime": 0,
             "servergenre": streams.getStreamConf(stream).genre,
             "servergenre2": "",

--- a/intern/streams/streams.js
+++ b/intern/streams/streams.js
@@ -320,20 +320,27 @@ const getUniqueListeners = (streamName) => {
     return uniqueListeners
 }
 
-const numberOfListerners = (streamName, admin = false) => {
-    if (config.hideListenerCount && !admin) {
+const numberOfListerners = (streamName) => {
+    if (config.hideListenerCount) {
         return 0
     }
     return getListeners(streamName).length
 }
 
-const numberOfUniqueListerners = (streamName, admin = false) => {
-    if (config.hideListenerCount && !admin) {
+const numberOfUniqueListerners = (streamName) => {
+    if (config.hideListenerCount) {
         return 0
     }
     return getListeners(streamName).length
 }
 
+const realNumberOfListerners = (streamName) => {
+    return getListeners(streamName).length
+}
+
+const realNumberOfUniqueListerners = (streamName) => {
+    return getListeners(streamName).length
+}
 const getPreBuffer = (streamName) => {
     return streamPreBuffer[streamName]
 }
@@ -367,6 +374,8 @@ module.exports.getListeners = getListeners
 module.exports.getUniqueListeners = getUniqueListeners
 module.exports.numberOfListerners = numberOfListerners
 module.exports.numberOfUniqueListerners = numberOfUniqueListerners
+module.exports.realNumberOfListerners = realNumberOfListerners
+module.exports.realNumberOfUniqueListerners = realNumberOfUniqueListerners
 module.exports.getPreBuffer = getPreBuffer
 module.exports.getPastMedatada = getPastMedatada
 module.exports.configFileInfo = configFileInfo

--- a/intern/streams/streams.js
+++ b/intern/streams/streams.js
@@ -320,11 +320,17 @@ const getUniqueListeners = (streamName) => {
     return uniqueListeners
 }
 
-const numberOfListerners = (streamName) => {
+const numberOfListerners = (streamName, admin = false) => {
+    if (config.hideListenerCount && !admin) {
+        return 0
+    }
     return getListeners(streamName).length
 }
 
-const numberOfUniqueListerners = (streamName) => {
+const numberOfUniqueListerners = (streamName, admin = false) => {
+    if (config.hideListenerCount && !admin) {
+        return 0
+    }
     return getListeners(streamName).length
 }
 

--- a/public/index.jade
+++ b/public/index.jade
@@ -36,9 +36,10 @@ html(lang="en")
                             p.lead(id="meta-"+currentStream) #{meta.song}
                             button.btn.btn-success.btn-circle.btn-xl(onClick="pressedPlayButton('"+hostname+"/streams/"+currentStream+"')")
                                 i.fa.fa-play#playStopButton
-                            if listencount==1
-                                p.listencount(id="listencount-"+currentStream) 1 person is listening right now.
-                            else
-                                p.listencount(id="listencount-"+currentStream) #{listencount} people are listening right now.
+                            if listencount !== false
+                                if listencount==1
+                                    p.listencount(id="listencount-"+currentStream) 1 person is listening right now.
+                                else
+                                    p.listencount(id="listencount-"+currentStream) #{listencount} people are listening right now.
                         else
                             h1.cover-heading No streams found.

--- a/public/index.jade
+++ b/public/index.jade
@@ -36,7 +36,7 @@ html(lang="en")
                             p.lead(id="meta-"+currentStream) #{meta.song}
                             button.btn.btn-success.btn-circle.btn-xl(onClick="pressedPlayButton('"+hostname+"/streams/"+currentStream+"')")
                                 i.fa.fa-play#playStopButton
-                            if listencount !== false
+                            if listencount !== null
                                 if listencount==1
                                     p.listencount(id="listencount-"+currentStream) 1 person is listening right now.
                                 else


### PR DESCRIPTION
The hideListenerCount allows to hide the count for the public. All Icecast/SHOUTcast APIs (without the API key!) will report 0 including to the YP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/cast/29)
<!-- Reviewable:end -->
