### PR TITLE
YP host corrections

### DIFF
--- a/hooks/action/icecast-yp.js
+++ b/hooks/action/icecast-yp.js
@@ -26,8 +26,10 @@ let addToDir = (stream) => {
 
     if (config.hostname.split(":").length === 3) { // if a non standard port is used
         hostname = config.hostname;
-    } else {
-        hostname = config.hostname + ":" + ((config.hostname.indexOf("https://") !== -1) ? 443 : 80);
+    } else if (config.httpPort === 0) { // if only serves over https
+        hostname = config.hostname + ":" + config.httpsPort.toString()
+    } else { // If both or only http, use http as some directories may have https issues
+        hostname = config.hostname.replace("https://", "http://") + ":" + config.httpPort.toString()
     }
 
     var sendRequestToDirectory = (directory) => {


### PR DESCRIPTION
Use the correct hostnames for the YP and prefer HTTP if available as most YP directories are not fully HTTPS ready.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/cast/41)
<!-- Reviewable:end -->
