### PR TITLE
Add redirect for SHOUTcast's /stream and /;

### DIFF
--- a/intern/HTTP/apps/shoutcastv2.js
+++ b/intern/HTTP/apps/shoutcastv2.js
@@ -155,6 +155,14 @@ export default function (app) {
                 res.status(400).send("Not supported")
         }
     })
+
+    app.get("/stream/:sid", (req, res) => {
+        const stream = sidToStream(req.params.sid)
+        res.redirect(`/streams/${stream}`)
+    })
+    app.get("/;", (req, res) => { // we didn't want but we must
+        res.redirect(`/streams/${streams.primaryStream}`)
+    })
 }
 
 // functions used for the calls


### PR DESCRIPTION
Adds the SHOUTcast stream routes to be redirected to the Cast one as not all players seems to offer a custom stream path.

*Needs to be tested*