### PR TITLE
HLS 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM ${ARCHREPO}/node:8
 ARG QEMU_ARCH
 COPY qemu-${QEMU_ARCH}-static /usr/bin/
 
+RUN apt-get update && apt-get install -y ffmpeg
+
 COPY ./ /opt/cast/
 WORKDIR /opt/cast/
 

--- a/intern/HTTP/server.js
+++ b/intern/HTTP/server.js
@@ -1,6 +1,9 @@
 import fs from "fs"
 const app = require("express")()
 
+// Used in route handlers to catch async exceptions as if they were synchronous.
+const wrap = fn => (...args) => fn(...args).catch(args[2]);
+
 global.io = require("socket.io")()
 
 if (config.httpsPort !== 0) {
@@ -39,7 +42,7 @@ fs.stat(global.localdir + "/hooks/http/", (err) => {
     }
 })
 
-streamOutput(app)
+streamOutput(app, wrap)
 streamInput(global.config)
 
 module.exports = app

--- a/intern/streams/hls.js
+++ b/intern/streams/hls.js
@@ -5,12 +5,13 @@ import { spawn } from "child_process"
 export default class HLSHandler {
 
     tempPath = ""
+    tmpobj
     inputStream
     process
 
     constructor(inputStream) {
-        var tmpobj = tmp.dirSync();
-        this.tempPath = tmpobj.name
+        this.tmpobj = tmp.dirSync();
+        this.tempPath = this.tmpobj.name
 
         this.inputStream = inputStream
     }
@@ -42,5 +43,6 @@ export default class HLSHandler {
 
     stop() {
         this.process.kill()
+        this.tmpobj.removeCallback()
     }
 }

--- a/intern/streams/hls.js
+++ b/intern/streams/hls.js
@@ -8,12 +8,14 @@ export default class HLSHandler {
     tmpobj
     inputStream
     process
+    name = ""
 
-    constructor(inputStream) {
+    constructor(inputStream, name) {
         this.tmpobj = tmp.dirSync();
         this.tempPath = this.tmpobj.name
 
         this.inputStream = inputStream
+        this.name = name
     }
 
     /*
@@ -32,10 +34,11 @@ export default class HLSHandler {
             "-hls_list_size", "5",
             "-hls_wrap", "5",
             "-hls_flags", "delete_segments",
+            "-metadata", `title=${this.name}`,
             `${this.tempPath}/hls.m3u8`
         ],
         { 
-            stdio: ['pipe', process.stdout, process.stdout]
+            stdio: ['pipe', null, null]
         });
     
         this.inputStream.pipe(this.process.stdin);

--- a/intern/streams/hls.js
+++ b/intern/streams/hls.js
@@ -11,7 +11,6 @@ export default class HLSHandler {
     constructor(inputStream) {
         var tmpobj = tmp.dirSync();
         this.tempPath = tmpobj.name
-        console.log('Dir: ', tmpobj.name);
 
         this.inputStream = inputStream
     }

--- a/intern/streams/hls.js
+++ b/intern/streams/hls.js
@@ -1,0 +1,47 @@
+import tmp from "tmp"
+import { spawn } from "child_process"
+
+
+export default class HLSHandler {
+
+    tempPath = ""
+    inputStream
+    process
+
+    constructor(inputStream) {
+        var tmpobj = tmp.dirSync();
+        this.tempPath = tmpobj.name
+        console.log('Dir: ', tmpobj.name);
+
+        this.inputStream = inputStream
+    }
+
+    /*
+        We use ffmpeg as the best way to implement this atm.
+        Transmuxing in JS will take more resources and currently there is no good library available
+        In order to move fast we decided to let ffmpeg do the job here in a subprocess.
+    */
+
+    start() {
+        this.process = spawn('ffmpeg', [
+            "-y",
+            "-i", "-",
+            "-codec", "copy",
+            "-hls_time", "9",
+            "-hls_segment_filename", `${this.tempPath}/seq%03d.ts`,
+            "-hls_list_size", "5",
+            "-hls_wrap", "5",
+            "-hls_flags", "delete_segments",
+            `${this.tempPath}/hls.m3u8`
+        ],
+        { 
+            stdio: ['pipe', null, null]
+        });
+    
+        this.inputStream.pipe(this.process.stdin);
+    }
+
+    stop() {
+        this.process.kill()
+    }
+}

--- a/intern/streams/hls.js
+++ b/intern/streams/hls.js
@@ -35,7 +35,7 @@ export default class HLSHandler {
             `${this.tempPath}/hls.m3u8`
         ],
         { 
-            stdio: ['pipe', null, null]
+            stdio: ['pipe', process.stdout, process.stdout]
         });
     
         this.inputStream.pipe(this.process.stdin);

--- a/intern/streams/httphandler.js
+++ b/intern/streams/httphandler.js
@@ -280,6 +280,7 @@ export default (app, wrap) => {
         let playlist = await readFile(`${global.streams.hlsHanders[stream].tempPath}/hls.m3u8`, "utf8")
         playlist = playlist.replace(/\.ts/g, `.ts?id=${req.query.id}`)
 
+        res.setHeader("Cache-Control", "max-age=0, no-cache, no-store")
         res.type("application/vnd.apple.mpegurl").send(playlist)
     }
 

--- a/intern/streams/httphandler.js
+++ b/intern/streams/httphandler.js
@@ -1,7 +1,11 @@
+import fs from "fs"
+import util from "util"
 import icy from "./icy"
 import * as geolock from "../geolock/geolock.js"
 
-export default (app) => {
+const readFile = util.promisify(fs.readFile)
+
+export default (app, wrap) => {
     if (!app) {
         return
     }
@@ -10,6 +14,7 @@ export default (app) => {
         global.streams = require("./streams.js")
     }
 
+    // classic stream clients use HEAD calls to get stream info
     app.head("/streams/:stream", (req, res) => {
         if (!geolock.isAllowed(req.ip)) {
             return res.status(401).send()
@@ -61,15 +66,20 @@ export default (app) => {
 
     })
 
-    app.get("/hls/:stream/:segment", (req, res) => {
+    // HLS stream handler
+    app.get("/hls/:stream/:file", wrap(async (req, res) => {
         if (!geolock.isAllowed(req.ip)) {
             return res.status(401).send("Your country is not allowed to tune in to the stream")
         }
         if (!global.streams.streamExists(req.params.stream)) {
-            res.status(404).send("Stream not found")
-            return
+            return res.status(404).send("Stream not found")
         }
-        if (!req.query.id || !global.streams.listenerIdExists(req.params.stream, req.query.id, req.ip, req.headers["user-agent"])) {
+
+        if (req.params.file.split(".")[1] === "m3u8") {
+            return serveM3U8ForStream(req.params.stream, req, res)
+        }
+       
+       if (!req.query.id || !global.streams.listenerIdExists(req.params.stream, req.query.id, req.ip, req.headers["user-agent"])) {
             return res.status(401).send("Invalid id")
         }
 
@@ -78,26 +88,21 @@ export default (app) => {
         }
 
         global.streams.hlsLastHit[req.params.stream][req.query.id] = Math.round((new Date()).getTime() / 1000)
-
-        var streamConf = global.streams.getStreamConf(req.params.stream)
-
+        
         // generate response header
         const headers = {
-            "Content-Type": streamConf.type || "audio/mpeg",
-            "Connection": "close",
-            "Access-Control-Allow-Origin": "*",
+            //"Content-Type": "video/MP2T",
             "X-Begin": "Thu, 30 Jan 2014 17:20:00 GMT",
             "Cache-Control": "no-cache",
             "Expires": "Sun, 9 Feb 2014 15:32:00 GMT",
         }
-        if (!global.streams.hlsPool[req.params.stream][req.params.segment]) {
-            return res.status(404).send("Segment not found")
-        }
-        res.writeHead(200, headers);
-        res.write(global.streams.hlsPool[req.params.stream][req.params.segment])
-        res.end()
-    })
+    
+        res.sendFile(`${global.streams.hlsHanders[req.params.stream].tempPath}/${req.params.file.replace(/\.\./g, "")}`, {
+            headers,
+        })
+    }))
 
+    // Classic stream handler
     app.get("/streams/:stream", (req, res) => {
 
         if (!geolock.isAllowed(req.ip)) {
@@ -258,22 +263,30 @@ export default (app) => {
             return res.status(404).send("Stream not found")
         }
 
+        return res.redirect(`/hls/${stream}/hls.m3u8`);
+    }
+
+    const serveM3U8ForStream = async (stream, req, res) => {
         if (!req.query.id || !global.streams.listenerIdExists(stream, req.query.id, req.ip, req.headers["user-agent"])) {
             var listenerID = global.streams.listenerTunedIn(stream, req.ip, req.headers["user-agent"], Math.round((new Date()).getTime() / 1000), true)
             if (!global.streams.hlsLastHit[req.params.stream]) {
                 global.streams.hlsLastHit[stream] = {}
             }
             global.streams.hlsLastHit[stream][listenerID] = Math.round((new Date()).getTime() / 1000)
-            return res.redirect("/streams/" + stream + ".m3u8?id=" + listenerID);
+            return res.redirect(`/hls/${stream}/hls.m3u8?id=${listenerID}`);
         }
-
         global.streams.hlsLastHit[stream][req.query.id] = Math.round((new Date()).getTime() / 1000)
-        res.setHeader("Content-Type", "application/vnd.apple.mpegurl")
-        let response = `#EXTM3U\n#EXT-X-VERSION:5\n#EXT-X-TARGETDURATION:5\n#EXT-X-MEDIA-SEQUENCE:${global.streams.hlsDeleteCount[stream]}\n`
-        for (let index of global.streams.hlsIndexes[stream]) {
-            response += `#EXTINF:2.0,\n${global.config.hostname}/hls/${stream}/${index}?id=${req.query.id}\n`
-        }
-        res.send(response)
+        
+        let playlist = await readFile(`${global.streams.hlsHanders[stream].tempPath}/hls.m3u8`, "utf8")
+        playlist = playlist.replace(/\.ts/g, `.ts?id=${req.query.id}`)
+
+        res.writeHead(200, {
+            "Content-Type": "application/vnd.apple.mpegurl",
+        })
+
+        //TODO: set headers
+        res.write(playlist)
+        res.end()
     }
 
 }

--- a/intern/streams/httphandler.js
+++ b/intern/streams/httphandler.js
@@ -268,7 +268,7 @@ export default (app) => {
         }
 
         global.streams.hlsLastHit[stream][req.query.id] = Math.round((new Date()).getTime() / 1000)
-        res.setHeader("Content-Type", "audio/x-mpegurl")
+        res.setHeader("Content-Type", "application/vnd.apple.mpegurl")
         let response = `#EXTM3U\n#EXT-X-VERSION:5\n#EXT-X-TARGETDURATION:5\n#EXT-X-MEDIA-SEQUENCE:${global.streams.hlsDeleteCount[stream]}\n`
         for (let index of global.streams.hlsIndexes[stream]) {
             response += `#EXTINF:2.0,\n${global.config.hostname}/hls/${stream}/${index}?id=${req.query.id}\n`

--- a/intern/streams/httphandler.js
+++ b/intern/streams/httphandler.js
@@ -280,13 +280,7 @@ export default (app, wrap) => {
         let playlist = await readFile(`${global.streams.hlsHanders[stream].tempPath}/hls.m3u8`, "utf8")
         playlist = playlist.replace(/\.ts/g, `.ts?id=${req.query.id}`)
 
-        res.writeHead(200, {
-            "Content-Type": "application/vnd.apple.mpegurl",
-        })
-
-        //TODO: set headers
-        res.write(playlist)
-        res.end()
+        res.type("application/vnd.apple.mpegurl").send(playlist)
     }
 
 }

--- a/intern/streams/streams.js
+++ b/intern/streams/streams.js
@@ -1,5 +1,6 @@
 import stream from "stream"
 import _ from "underscore"
+import HLSHandler from "./hls"
 
 if (config.geoservices && config.geoservices.enabled && !global.maxmind) {
     global.maxmind = require("maxmind").open(global.config.geoservices.maxmindDatabase)
@@ -24,11 +25,10 @@ let primaryStream = ""
 let latestListenerID = {} // {stream:id}
 
 if (global.config.hls) {
-    var hlsBuffer = {} // {stream:[buffers]}
-    var hlsPool = {} // {stream:{unixtime:song data}}
-    var hlsDeleteCount = {} // {stream:count}
     var hlsLastHit = {} // {stream:{id:unixtime}}
-    var hlsIndexes = {} // {stream:[indexes]}
+    var hlsHanders = {} // {stream:[handler]}
+
+    // handle HLS hits
     setInterval(() => {
         let now = Math.round((new Date()).getTime() / 1000)
         for (let id in streams) {
@@ -99,35 +99,8 @@ const addStream = function (inputStream, conf) {
     }
 
     if (global.config.hls) {
-        hlsDeleteCount[conf.stream] = 0
-
-        inputStreams[conf.stream].on("data", (chunk) => {
-            if (typeof hlsBuffer[conf.stream] === "undefined") {
-                hlsBuffer[conf.stream] = []
-            }
-            hlsBuffer[conf.stream].push(chunk)
-        });
-        var hlsInterval = setInterval(() => {
-            const now = new Date().getTime()
-            if (!hlsPool[conf.stream]) {
-                hlsPool[conf.stream] = {}
-            }
-            if (!hlsIndexes[conf.stream]) {
-                hlsIndexes[conf.stream] = []
-            }
-            hlsPool[conf.stream][now] = Buffer.concat(hlsBuffer[conf.stream])
-            hlsBuffer[conf.stream] = []
-            hlsIndexes[conf.stream].push(now)
-            if (hlsIndexes[conf.stream].length > 7) {
-                hlsIndexes[conf.stream] = hlsIndexes[conf.stream].slice(1, hlsIndexes.length)
-                hlsDeleteCount[conf.stream]++
-            }
-            for (var id in hlsPool[conf.stream]) {
-                if (id < now - (5000 * 20)) {
-                    delete hlsPool[conf.stream][id]
-                }
-            }
-        }, 5000)
+        hlsHanders[conf.stream] = new HLSHandler(inputStreams[conf.stream])
+        hlsHanders[conf.stream].start()
     }
 
 
@@ -171,6 +144,9 @@ const removeStream = (streamName) => {
     streamConf = _.omit(streamConf, streamName)
     streamMetadata = _.omit(streamMetadata, streamName)
     streamListeners = _.omit(streamListeners, streamName)
+    if (global.config.hls && hlsHanders[conf.stream]) {
+        hlsHanders[conf.stream].stop()
+    }
     events.emit("removeStream", streamName)
 }
 
@@ -366,7 +342,5 @@ module.exports.getPastMedatada = getPastMedatada
 module.exports.configFileInfo = configFileInfo
 module.exports.streamID = streamID
 module.exports.endStream = endStream
-module.exports.hlsPool = hlsPool
-module.exports.hlsIndexes = hlsIndexes
+module.exports.hlsHanders = hlsHanders
 module.exports.hlsLastHit = hlsLastHit
-module.exports.hlsDeleteCount = hlsDeleteCount

--- a/intern/streams/streams.js
+++ b/intern/streams/streams.js
@@ -99,7 +99,7 @@ const addStream = function (inputStream, conf) {
     }
 
     if (global.config.hls) {
-        hlsHanders[conf.stream] = new HLSHandler(inputStreams[conf.stream])
+        hlsHanders[conf.stream] = new HLSHandler(inputStreams[conf.stream], conf.name)
         hlsHanders[conf.stream].start()
     }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "socket.io": "^2.0.2",
     "socket.io-client": "^2.0.2",
     "stream-stack": "~1.1.4",
+    "tmp": "0.0.33",
     "underscore": "~1.9.0",
     "xml": "~1.0.0"
   },


### PR DESCRIPTION
Cast had experimental HLS support based upon the line in the standard that defined that MP3 and AAC ADTS files cut in pieces were also valid. However, it seems this is never used and MPEG TS is also used for audio only. 

This PR is a re-do of HLS in Cast, using ffmpeg to transmux the audio input into MPEG TS files. This might not be the best solution to sub-process ffmpeg but it is the one that gets it working everywhere the fastest, and since FFMPEG doesn't re-encode the CPU/RAM overhead is minimal 

Fixes #92