### PR TITLE
feat(config): support config.yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9493,6 +9493,11 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz",
           "integrity": "sha1-7Qeb4oaCFH5v2aNMwrDB4OxkU+4="
+        },
+        "yaml": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-0.2.3.tgz",
+          "integrity": "sha1-tUUOkudu82td0k42YAkeuu7z5cc="
         }
       }
     },
@@ -12012,9 +12017,9 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yaml": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-0.2.3.tgz",
-      "integrity": "sha1-tUUOkudu82td0k42YAkeuu7z5cc="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     },
     "yargs": {
       "version": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "stream-stack": "~1.1.4",
     "tmp": "0.2.1",
     "underscore": "~1.10.2",
-    "xml": "~1.0.1"
+    "xml": "~1.0.1",
+    "yaml": "^1.10.0"
   },
   "snyk": true,
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -11,13 +11,16 @@ global.localdir = __dirname;
 global.cast = {};
 
 var fs = require("fs");
+var YAML = require('yaml')
 try {
     if (process.argv.length > 2 && fs.statSync(process.argv[process.argv.length - 1]).isFile()) {
         var configFile = process.argv[process.argv.length - 1]
+    } else if (fs.existsSync(global.localdir + "/config.yaml")) {
+        configFile = global.localdir + "/config.yaml"
     }
-    global.config = JSON.parse(fs.readFileSync(configFile || global.localdir + "/config.json", "utf8"));
+    global.config = YAML.parse(fs.readFileSync(configFile || global.localdir + "/config.json", "utf8"));
 } catch (error) {
-    console.error("Failed to load the config file. Are you sure you have a valid config.json?".red);
+    console.error("Failed to load the config file. Are you sure you have a valid config.json or config.yaml?".red);
     console.error("The error was:", error.message.grey);
     process.exit(1);
 }


### PR DESCRIPTION
Use the `yaml` package to parse the config so it can also support yaml. Checks if a config.yaml exists and prefers that if does. The config specified on the command line can be either YAML or JSON with this change.

As mentioned in #260 YAML is a superset of JSON so the yaml package will also parse JSON configs w/o them needing to still be handled by `JSON.parse`.

Fixes #260 